### PR TITLE
Allow multiple attachments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+clean:
+	find . -name \*.pyc -delete
+	find . -name \*.so -delete
+	find . -name __pycache__ -delete
+	rm -rf .coverage build dist *.egg-info
+
+build:
+	python setup.py sdist bdist_wheel
+
+upload:
+	twine upload dist/*
+
+install:
+	pip install .
+
+testing_install:
+	pip install '.[test]'
+
+test:
+	PYTHONPATH=. pytest tests

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ You need :
 - git installed
 - an SSH key authorized for toucantoco's private github repos
 
-Replace `1.1.1` with the git tag you want :
+Replace `1.1.3` with the git tag you want :
 
 ```bash
-$ pip install -e 'git+ssh://git@github.com/toucantoco/tc_mailmanager@1.1.1#egg=tc_mailmanager'
+$ pip install -e 'git+ssh://git@github.com/toucantoco/tc_mailmanager@1.1.3#egg=tc_mailmanager'
 ```
 
-Or put `-e git+ssh://git@github.com/toucantoco/tc_mailmanager@1.1.1#egg=tc_mailmanager` in your `requirements.txt`
+Or put `-e git+ssh://git@github.com/toucantoco/tc_mailmanager@1.1.3#egg=tc_mailmanager` in your `requirements.txt`

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+    post:
+        - pyenv global 3.6.2
+    python:
+        version: 3.6.2
+
+dependencies:
+    override:
+        - make clean build testing_install
+
+test:
+    override:
+        - make test

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 
 dependencies:
     override:
-        - make clean build testing_install
+        - make clean testing_install
 
 test:
     override:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-VERSION = '1.1.2'
+VERSION = '1.1.3'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
**Before** : we could only add one attachment (`dict`)
**After** : multiple attachments allowed (`list of dicts`). This is retrocompatible.