### PR TITLE
Fix :: update sendgrid python api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ clean:
 	find . -name \*.pyc -delete
 	find . -name \*.so -delete
 	find . -name __pycache__ -delete
-	rm -rf .coverage build dist *.egg-info
+	rm -rf .coverage build dist *.egg-info .pytest_cache
 
 build:
 	python setup.py sdist bdist_wheel
@@ -17,4 +17,5 @@ testing_install:
 	pip install '.[test]'
 
 test:
+	flake8 tc_mailmanager tests
 	PYTHONPATH=. pytest tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,11 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[flake8]
+exclude = __init__.py
+max_line_length = 100
+
+[tool:pytest]
+addopts = -v --pep8
+pep8maxlinelength = 99

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-VERSION = '1.2.1'
+VERSION = '1.2.2'
 
 here = path.abspath(path.dirname(__file__))
 
@@ -28,8 +28,8 @@ setup(
     ],
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
-        'sendgrid>=3,<6',
+        'sendgrid>=5,<6',
         'tctc_envelopes==0.5',
     ],
-    extras_require={'test': ['pytest', 'mock']},
+    extras_require={'test': ['pytest', 'pytest-mock', 'pytest-pep8', 'flake8']},
 )

--- a/tc_mailmanager/mail_manager.py
+++ b/tc_mailmanager/mail_manager.py
@@ -23,17 +23,17 @@ class SendGridV3Provider(object):
         attachments = [attachments] if isinstance(attachments, dict) else attachments
         for att_dict in attachments:
             attachment = Attachment()
-            attachment.set_content(att_dict['content'])
-            attachment.set_filename(att_dict['filename'])
-            attachment.set_type(att_dict.get('type'))
-            attachment.set_disposition(att_dict.get('disposition'))
+            attachment.content = att_dict['content']
+            attachment.filename = att_dict['filename']
+            attachment.type = att_dict.get('type')
+            attachment.disposition = att_dict.get('disposition')
             mail.add_attachment(attachment)
         return mail
 
     def create_message(self, email_attributes):
         mail = Mail()
-        mail.set_from(Email(email_attributes['FromEmail'], email_attributes['FromName']))
-        mail.set_subject(email_attributes['Subject'])
+        mail.from_email = Email(email_attributes['FromEmail'], email_attributes['FromName'])
+        mail.subject = email_attributes['Subject']
         p = Personalization()
         for recipient in email_attributes['Recipients']:
             p.add_to(Email(recipient['Email'], recipient.get('Name')))
@@ -110,7 +110,7 @@ class SMTPProvider(object):
         return message  # type(message) -> Envelope object
 
     def send_message(self, message):
-        dest = [d[0] for d in message.to_addr]
+        dest = [(d[0] if isinstance(d, tuple) else d) for d in message.to_addr]
         self.logger.info("[smtp] sending email to {}".format(dest))
         try:
             conn, send_result = message.send(
@@ -201,11 +201,13 @@ class MailManager(object):
 
     def _validate_email_template_empty_value(self, field_name, field_content):
         if len(field_content) == 0 or field_content.isspace():
-            raise InvalidEmailTemplateException('The "{}" of email template is empty'.format(field_name))
+            raise InvalidEmailTemplateException(
+                'The "{}" of email template is empty'.format(field_name))
 
     def _validate_email_template_recipients(self, recipients):
         if len(recipients) == 0:
-            raise InvalidEmailTemplateException('The email template should have at least one recipient')
+            raise InvalidEmailTemplateException(
+                'The email template should have at least one recipient')
 
 
 class InvalidEmailTemplateException(Exception):

--- a/tests/test_mail_manager.py
+++ b/tests/test_mail_manager.py
@@ -1,45 +1,95 @@
 # coding: utf-8
 
 from collections import namedtuple
-from unittest import TestCase
-from mock import MagicMock
+
+import pytest
+from envelopes import Envelope
 
 from tc_mailmanager import MailManager, InvalidEmailTemplateException
+from tc_mailmanager.mail_manager import SendGridV3Provider, SMTPProvider
 
 
-class MailManagerTest(TestCase):
+@pytest.fixture(scope="module")
+def mail_manager():
+    credentials = "test"
+    return MailManager(credentials)
 
-    @classmethod
-    def setUpClass(cls):
-        credentials = "test"
-        cls.mail_manager = MailManager(credentials)
-        cls.successful_response = namedtuple('Rep', ['status_code'])(202)
 
-    def test_send_email(self):
-        """
-        It should send email with email provider(mailjet)
-        """
-        email_attributes = {
-            'Subject': 'Test email',
-            'Html-part': 'Test content',
-            'Recipients': [{'Email': 'test@toucantoco.com'}]
-        }
+@pytest.fixture(scope="module")
+def successful_response():
+    return namedtuple('Rep', ['status_code'])(202)
 
-        self.mail_manager.provider.send_message = MagicMock(return_value=self.successful_response)
-        resp = self.mail_manager.send_email(email_attributes)
-        self.assertEqual(resp, self.successful_response)
 
-    def test_validate_email_template_empty_value(self):
-        field_name, field_content = 'Subject', 'Want some viagra ?'
-        ret = self.mail_manager._validate_email_template_empty_value(field_name, field_content)
-        self.assertIsNone(ret)
+@pytest.fixture
+def email_with_attachments():
+    return {
+        'FromEmail': 'noreply@toucantoco.com',
+        'FromName': 'Toucan Toco',
+        'Subject': 'Toucan Toco - Take a look !',
+        'Html-part': '<h1>html part</h1>',
+        'Attachments': [
+            {
+                'filename': 'screenshot.png',
+                'content': b'QA==',
+                'type': 'image/png',
+                'disposition': 'attachment',
+            },
+            {
+                'filename': 'screenshot_bis.png',
+                'content': b'QA==',
+                'type': 'image/png',
+                'disposition': 'attachment',
+            }
+        ],
+        'Recipients': [{'Email': 'test1@toucantoco.com', 'Name': 'Test'},
+                       {'Email': 'test2@toucantoco.com'}],
+    }
 
-        # empty subject field:
-        field_name, field_content = 'Subject', ''
-        with self.assertRaises(InvalidEmailTemplateException):
-            self.mail_manager._validate_email_template_empty_value(field_name, field_content)
 
-        # only blank characters in subject field
-        field_name, field_content = 'Subject', ' \n  '
-        with self.assertRaises(InvalidEmailTemplateException):
-            self.mail_manager._validate_email_template_empty_value(field_name, field_content)
+def test_sendgrid_provider(email_with_attachments):
+    provider = SendGridV3Provider(api_key="foo")
+    msg = provider.create_message(email_with_attachments)
+
+    assert isinstance(msg, dict)
+    pers = msg['personalizations'][0]['to']
+    dest = [d['email'] for d in pers]
+    assert dest == ['test1@toucantoco.com', 'test2@toucantoco.com']
+
+
+def test_smtp_provider(mail_manager, email_with_attachments):
+    provider = SMTPProvider(smtp_credentials={
+        'host': 'localhost', 'port': 25, 'login': '', 'password': ''
+    })
+    msg = provider.create_message(mail_manager._setup_email_template(email_with_attachments))
+
+    assert isinstance(msg, Envelope)
+    dest = [(d[0] if isinstance(d, tuple) else d) for d in msg.to_addr]
+    assert dest == ['test1@toucantoco.com', 'test2@toucantoco.com']
+
+
+def test_send_email(mocker, mail_manager, successful_response):
+    mocker.patch.object(mail_manager.provider, 'send_message').return_value = successful_response
+    email_attributes = {
+        'Subject': 'Test email',
+        'Html-part': 'Test content',
+        'Recipients': [{'Email': 'test@toucantoco.com'}]
+    }
+
+    resp = mail_manager.send_email(email_attributes)
+    assert resp == successful_response
+
+
+def test_validate_email_template_empty_value(mail_manager):
+    field_name, field_content = 'Subject', 'Want some viagra ?'
+    ret = mail_manager._validate_email_template_empty_value(field_name, field_content)
+    assert ret is None
+
+    # empty subject field:
+    field_name, field_content = 'Subject', ''
+    with pytest.raises(InvalidEmailTemplateException):
+        mail_manager._validate_email_template_empty_value(field_name, field_content)
+
+    # only blank characters in subject field
+    field_name, field_content = 'Subject', ' \n  '
+    with pytest.raises(InvalidEmailTemplateException):
+        mail_manager._validate_email_template_empty_value(field_name, field_content)


### PR DESCRIPTION
Python module `sendgrid` v5.3.0 API has slightly changed since v3.6.5 → fix our code, and add tests to catch these kind of changes next time.